### PR TITLE
add release workflow to GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@master
+
+      - name: install Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: 13.x
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: run tests
+        run: npm test
+
+      - name: publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: generate docs
+        run: npm run docs
+
+      - name: deploy docs
+        run: npm run gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  run-tests:
+    name: run tests
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@master
+
+      - name: install Node.js
+        uses: actions/setup-node@master
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: test
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: install Node.js
         uses: actions/setup-node@master
+        with:
+          node-version: 13.x
 
       - name: install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A JavaScript library for working with linguistic data in DLx format. For browser
 [![npm version](https://img.shields.io/npm/v/@digitallinguistics/javascript.svg)][npm]
 [![npm downloads](https://img.shields.io/npm/dt/@digitallinguistics/javascript.svg)][npm]
 [![GitHub issues](https://img.shields.io/github/issues/digitallinguistics/javascript.svg)][issues]
+[![GitHub test workflow status](https://github.com/digitallinguistics/javascript/workflows/tests/badge.svg)][tests]
 [![GitHub](https://img.shields.io/github/license/digitallinguistics/javascript.svg)][license]
 [![GitHub stars](https://img.shields.io/github/stars/digitallinguistics/javascript.svg?style=social)][GitHub]
 
@@ -79,5 +80,6 @@ Maintained by [Daniel W. Hieber][personal] (University of California, Santa Barb
 [personal]:     https://danielhieber.com
 [question]:     https://github.com/digitallinguistics/javascript/issues/new?assignees=&labels=question&template=question.md&title=
 [releases]:     https://github.com/digitallinguistics/javascript/releases
-[website]:      https://digitallinguistics.io
+[tests]:        https://github.com/digitallinguistics/javascript/actions
 [webpack]:      https://webpack.js.org/
+[website]:      https://digitallinguistics.io


### PR DESCRIPTION
This PR automates the release workflow using GitHub actions.

When a GitHub release is made, GitHub actions:
- runs tests
- publishes to npm
- generates developer documentation
- deploys developer documentation to `gh-pages` branch