### PR TITLE
Mls.set

### DIFF
--- a/src/models/MultiLangString.js
+++ b/src/models/MultiLangString.js
@@ -5,32 +5,6 @@
 import isLanguageTag from '../utilities/validate/isLanguageTag.js';
 
 /**
- * Proxy traps for the MultiLangString class
- * @type {Object}
- */
-const classTraps = {
-  construct(Target, args) {
-
-    const map = Reflect.construct(Target, args);
-
-    Object.defineProperty(map, `set`, {
-      configurable: true,
-      enumerable:   false,
-      get() {
-        return function(key, val) { // eslint-disable-line func-names
-          validateLanguageTag(key);
-          validateString(val);
-          return map.set.apply(this, [key, val]); // eslint-disable-line no-invalid-this
-        };
-      },
-    });
-
-    return map;
-
-  },
-};
-
-/**
  * Validates a language tag. Throws a type error if the input is not a valid IETF language tag.
  * @param {Any} input The input to validate
  */
@@ -104,10 +78,16 @@ class MultiLangString extends Map {
 
   }
 
+  set(key, val) {
+    validateLanguageTag(key);
+    validateString(val);
+    return super.set(key, val);
+  }
+
   toJSON() {
     return Object.fromEntries(this);
   }
 
 }
 
-export default new Proxy(MultiLangString, classTraps);
+export default MultiLangString;

--- a/src/models/MultiLangString.test.js
+++ b/src/models/MultiLangString.test.js
@@ -92,6 +92,12 @@ describe(modelName, () => {
 
   });
 
+  it(`MultiLangString.prototype.set()`, () => {
+    const mls = new MultiLangString;
+    const setData = () => mls.set(`hello`, `world`);
+    expect(setData).not.toThrow();
+  });
+
   it(`MultiLangString.prototype.toJSON()`, () => {
 
     const mls  = new MultiLangString(sampleData);


### PR DESCRIPTION
This PR fixes an error where the call stack was exceeded whenever `MultiLangString.prototype.set()` is called. (closes #120)

## Checklist

- [x] Check out the [Contributing Guidelines][contributing] if you need help getting started with your pull request.

- [x] [Open an issue][issues] for the change (if one doesn't already exist).

- [x] Update tests for planned changes. Check that they are failing. (`npm test`)

- [x] Write code to pass the tests. (`npm test`)

- [x] Add inline code commenting (using [JSDoc][JSDoc] style). Add links to cross-referenced modules, and the DLx data format.

- [x] Generate the developer documentation (`npm run docs`) and check your changes by opening `docs/index.html` in a browser.

[contributing]: https://github.com/digitallinguistics/javascript/blob/master/.github/CONTRIBUTING.md
[issues]:       https://github.com/digitallinguistics/javascript/issues
[JSDoc]:        https://jsdoc.app/
