### PR TITLE
Add Language.iso

### DIFF
--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -67,15 +67,14 @@ class Language extends Model {
           return this.#iso;
         },
         set(val) {
+          validateISOCode(val);
           this.#iso = new String(val);
-          // VALIDATE DATA
-          validateISOCode(this.#iso);
         },
       }
     });
 
     this.name = data.name;
-    if ('iso' in data) this.iso = data.iso;
+    if (`iso` in data) this.iso = data.iso;
 
   }
 

--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -2,9 +2,9 @@
  * @module models.Language
  */
 
+import isISOCode       from '../utilities/validate/isISO.js';
 import Model           from '../core/Model.js';
 import MultiLangString from './MultiLangString.js';
-import isISOCode        from '../utilities/validate/isISO.js';
 
 /**
  * Validates an ISO 639-3 language code. Throws a type error if the input is not a valid ISO 639-3 code.
@@ -49,6 +49,18 @@ class Language extends Model {
 
     Object.defineProperties(this, {
 
+      iso: {
+        configurable: true,
+        enumerable:   true,
+        get() {
+          return this.#iso;
+        },
+        set(val) {
+          validateISOCode(val);
+          this.#iso = new String(val); // eslint-disable-line no-new-wrappers
+        },
+      },
+
       name: {
         configurable: true,
         enumerable:   true,
@@ -60,17 +72,6 @@ class Language extends Model {
         },
       },
 
-      iso: {
-        configurable: true,
-        enumerable:   true,
-        get() {
-          return this.#iso;
-        },
-        set(val) {
-          validateISOCode(val);
-          this.#iso = new String(val);
-        },
-      }
     });
 
     this.name = data.name;

--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -41,7 +41,9 @@ class Language extends Model {
 
   /**
    * Create a new Language
-   * @param {Object} [data={}] The data to use for this Language object. Data should be formatted according to the [DLx Data Format's guidelines for Language data]{@link https://format.digitallinguistics.io/schemas/Language.html}.
+   * @param {Object}            [data={}]   The data to use for this Language object. Data should be formatted according to the [DLx Data Format's guidelines for Language data]{@link https://format.digitallinguistics.io/schemas/Language.html}.
+   * @param {String}            [data.iso]  The ISO 639-3 code for this language
+   * @param {Map|Object|String} [data.name] The name of this language. May be a string if English, an Object formatted as a [MultiLangString]{@link https://format.digitallinguistics.io/schemas/MultiLangString.html}, or a Map of language tags => transcriptions.
    */
   constructor(data = {}) {
 

--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -47,8 +47,6 @@ class Language extends Model {
 
     super(data);
 
-    this.#name = new MultiLangString(data.name);
-
     Object.defineProperty(this, `name`, {
       configurable: true,
       enumerable:   true,
@@ -60,6 +58,8 @@ class Language extends Model {
       },
     });
 
+    this.name = data.name;
+
     Object.defineProperty(this, `iso`, {
       get() {
         return this.#iso;
@@ -68,8 +68,7 @@ class Language extends Model {
         this.#iso = new String(val);
         // VALIDATE DATA
         validateISOCode(this.#iso);
-      }
-
+      },
     });
 
   }

--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -47,29 +47,35 @@ class Language extends Model {
 
     super(data);
 
-    Object.defineProperty(this, `name`, {
-      configurable: true,
-      enumerable:   true,
-      get() {
-        return this.#name;
+    Object.defineProperties(this, {
+
+      name: {
+        configurable: true,
+        enumerable:   true,
+        get() {
+          return this.#name;
+        },
+        set(val) {
+          this.#name = new MultiLangString(val);
+        },
       },
-      set(val) {
-        this.#name = new MultiLangString(val);
-      },
+
+      iso: {
+        configurable: true,
+        enumerable:   true,
+        get() {
+          return this.#iso;
+        },
+        set(val) {
+          this.#iso = new String(val);
+          // VALIDATE DATA
+          validateISOCode(this.#iso);
+        },
+      }
     });
 
     this.name = data.name;
-
-    Object.defineProperty(this, `iso`, {
-      get() {
-        return this.#iso;
-      },
-      set(val) {
-        this.#iso = new String(val);
-        // VALIDATE DATA
-        validateISOCode(this.#iso);
-      },
-    });
+    if ('iso' in data) this.iso = data.iso;
 
   }
 

--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -1,5 +1,22 @@
+/**
+ * @module models.Language
+ */
+
 import Model           from '../core/Model.js';
 import MultiLangString from './MultiLangString.js';
+import isISOCode from '../utilities/validate/isISO.js';
+
+/**
+ * Validates an ISO 639-3 language code. Throws a type error if the input is not a valid ISO 639-3 code.
+ * @param {Any} input The input to validate
+ */
+function validateISOCode(input) {
+  if (!isISOCode(input)) {
+    const e = new TypeError(`The language ISO 639-3 Code must be a vaild ISO code.`);
+    e.name = `ISOCodeError`;
+    throw e;
+  }
+}
 
 /**
  * A class representing a language, formatted according to the [DLx Data Format for a language]{@link https://format.digitallinguistics.io/schemas/Language.html}
@@ -14,6 +31,13 @@ class Language extends Model {
    * @type {Map}
    */
   #name;
+
+  /**
+  * The ISO 639-3 Code for this Language.
+  * @name models.Language#iso
+  * @type {string}
+  */
+  #iso;
 
   /**
    * Create a new Language
@@ -34,6 +58,18 @@ class Language extends Model {
       set(val) {
         this.#name = new MultiLangString(val);
       },
+    });
+
+    Object.defineProperty(this, `iso`, {
+      get() {
+        return this.#iso;
+      },
+      set(val) {
+        this.#iso = new String(val);
+        // VALIDATE DATA
+        validateISOCode(this.#iso);
+      }
+
     });
 
   }

--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -4,7 +4,7 @@
 
 import Model           from '../core/Model.js';
 import MultiLangString from './MultiLangString.js';
-import isISOCode from '../utilities/validate/isISO.js';
+import isISOCode        from '../utilities/validate/isISO.js';
 
 /**
  * Validates an ISO 639-3 language code. Throws a type error if the input is not a valid ISO 639-3 code.

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -66,7 +66,7 @@ describe(`Language`, () => {
     const lang = new Language();
     it(`Language.prototype.iso`, function() {
       expect(() => { lang.iso = `ctm`; }).not.toThrow();
-      expect(() => { lang.iso = `en`; }).toThrow();//e => e.name === `ISOCodeError`);
+      expect(() => { lang.iso = `en`; }).toThrow(e => e.name === `ISOCodeError`);
     });
 
   });

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -62,4 +62,13 @@ describe(`Language`, () => {
 
   });
 
+  describe(`Language.prototype.iso`, () => {
+    const lang = new Language();
+    it(`Language.prototype.iso`, function() {
+      expect(() => { lang.iso = `ctm`; }).not.toThrow();
+      expect(() => { lang.iso = `en`; }).toThrow();//e => e.name === `ISOCodeError`);
+    });
+
+  });
+
 });

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -62,13 +62,10 @@ describe(`Language`, () => {
 
   });
 
-  describe(`Language.prototype.iso`, () => {
-    const lang = new Language();
-    it(`Language.prototype.iso`, function() {
-      expect(() => { lang.iso = `ctm`; }).not.toThrow();
-      expect(() => { lang.iso = `en`; }).toThrowMatching(e => e.name === `ISOCodeError`);
-    });
-
+  const lang = new Language;
+  it(`Language.prototype.iso`, function() {
+    expect(() => { lang.iso = `ctm`; }).not.toThrow();
+    expect(() => { lang.iso = `en`; }).toThrowMatching(e => e.name === `ISOCodeError`);
   });
 
 });

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -66,7 +66,7 @@ describe(`Language`, () => {
     const lang = new Language();
     it(`Language.prototype.iso`, function() {
       expect(() => { lang.iso = `ctm`; }).not.toThrow();
-      expect(() => { lang.iso = `en`; }).toThrow(e => e.name === `ISOCodeError`);
+      expect(() => { lang.iso = `en`; }).toThrowMatching(e => e.name === `ISOCodeError`);
     });
 
   });

--- a/src/utilities/regexp/ISO.js
+++ b/src/utilities/regexp/ISO.js
@@ -1,8 +1,3 @@
-/* eslint-disable
-  max-len,
-  prefer-named-capture-group,
-*/
-
 /**
  * A regular expression for ISO 639-3 Language Codes.
  * @memberof utilities.regexp

--- a/src/utilities/regexp/ISO.js
+++ b/src/utilities/regexp/ISO.js
@@ -1,0 +1,14 @@
+/* eslint-disable
+  max-len,
+  prefer-named-capture-group,
+*/
+
+/**
+ * A regular expression for ISO 639-3 Language Codes.
+ * @memberof utilities.regexp
+ * @instance
+ * @type {RegExp}
+ */
+const isoCodeRegExp = /^[a-z]{3}$/u;
+
+export default isoCodeRegExp;

--- a/src/utilities/regexp/index.js
+++ b/src/utilities/regexp/index.js
@@ -4,5 +4,6 @@
  */
 
 import languageTagRegExp from './languageTag.js';
+import isoCodeRegExp from './ISO.js';
 
-export default { languageTagRegExp };
+export default { languageTagRegExp, isoCodeRegExp };

--- a/src/utilities/validate/index.js
+++ b/src/utilities/validate/index.js
@@ -4,5 +4,6 @@
  */
 
 import isLanguageTag from './isLanguageTag.js';
+import isISOCode from './isISO.js';
 
-export default { isLanguageTag };
+export default { isLanguageTag, isISOCode };

--- a/src/utilities/validate/isISO.js
+++ b/src/utilities/validate/isISO.js
@@ -1,4 +1,4 @@
-import isoCodeRegExp from '../regexp/languageTag.js';
+import isoCodeRegExp from '../regexp/ISO.js';
 
 /**
  * Checks whether the input is a valid ISO 639-3 language code.

--- a/src/utilities/validate/isISO.js
+++ b/src/utilities/validate/isISO.js
@@ -1,0 +1,14 @@
+import isoCodeRegExp from '../regexp/languageTag.js';
+
+/**
+ * Checks whether the input is a valid ISO 639-3 language code.
+ * @memberof utilities.validate
+ * @instance
+ * @param  {Any}     input The input to check
+ * @return {Boolean}
+ */
+function isISOCode(input) {
+  return isoCodeRegExp.test(input);
+}
+
+export default isISOCode;


### PR DESCRIPTION
## Related Issue
<!-- This project only accepts pull requests related to open issues. -->
<!-- Please open an issue for this change if one does not already exist. -->
closes #83 

## Description
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->
Added the ISO 639-3 field to the Language object and validated the data.

## Checklist

- [x] Check out the [Contributing Guidelines][contributing] if you need help getting started with your pull request.

- [x] [Open an issue][issues] for the change (if one doesn't already exist).

- [x] Update tests for planned changes. Check that they are failing. (`npm test`)

- [x] Write code to pass the tests. (`npm test`)

- [x] Add inline code commenting (using [JSDoc][JSDoc] style). Add links to cross-referenced modules, and the DLx data format.

- [x] Generate the developer documentation (`npm run docs`) and check your changes by opening `docs/index.html` in a browser.

[contributing]: https://github.com/digitallinguistics/javascript/blob/master/.github/CONTRIBUTING.md
[issues]:       https://github.com/digitallinguistics/javascript/issues
[JSDoc]:        https://jsdoc.app/
