### PR TITLE
Allow custom properties in language initialization 

### DIFF
--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -146,10 +146,8 @@ class Language extends Model {
 
     // Initialization
 
+    Object.assign(this, data);
     this.name = data.name;
-    if (`abbreviation` in data) this.abbreviation = data.abbreviation;
-    if (`glottolog` in data)    this.glottolog    = data.glottolog;
-    if (`iso` in data)          this.iso          = data.iso;
 
   }
 

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -20,7 +20,13 @@ describe(`Language`, () => {
     expect(() => { lang.abbreviation = `ctm`; }).not.toThrow();
     expect(() => { lang.abbreviation = `en!`; }).toThrowMatching(e => e.name === `AbbreviationError`);
   });
-  
+
+  it(`Custom Property`, () => {
+    const lang = new Language;
+    expect(() => { lang.deleted = true; }).not.toThrow();
+    expect(lang.deleted).toBe(true);
+  });
+
   it(`Glottocode`, () => {
     const lang = new Language;
     expect(() => { lang.glottolog = `stan1293`; }).not.toThrow();
@@ -79,5 +85,5 @@ describe(`Language`, () => {
     });
 
   });
-  
+
 });


### PR DESCRIPTION
## Related Issue
<!-- This project only accepts pull requests related to open issues. -->
<!-- Please open an issue for this change if one does not already exist. -->
closes #131 

## Description
<!-- In 1-3 sentences, provide an overview of what changes were made and why. -->
Adjusted code to allow for initialization of custom properties, and added tests for a custom boolean property `deleted`
## Checklist

- [x] Check out the [Contributing Guidelines][contributing] if you need help getting started with your pull request.

- [x] [Open an issue][issues] for the change (if one doesn't already exist).

- [x] Update tests for planned changes. Check that they are failing. (`npm test`)

- [x] Write code to pass the tests. (`npm test`)

- [x] Add inline code commenting (using [JSDoc][JSDoc] style). Add links to cross-referenced modules, and the DLx data format.

- [x] Generate the developer documentation (`npm run docs`) and check your changes by opening `docs/index.html` in a browser.

[contributing]: https://github.com/digitallinguistics/javascript/blob/master/.github/CONTRIBUTING.md
[issues]:       https://github.com/digitallinguistics/javascript/issues
[JSDoc]:        https://jsdoc.app/
