### PR TITLE
switch testing from Jasmine to Mocha + Chai

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,7 +8,7 @@ parserOptions:
 env:
   browser: false
   es6:     true
-  jasmine: true
+  mocha:   true
   node:    false
 rules:
   id-blacklist:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,12 @@ parserOptions:
   ecmaFeatures:
     impliedStrict: true
   sourceType: module
+overrides:
+  - files:
+      - '*.test.js'
+      - '*.spec.js'
+    rules:
+      no-unused-expressions: 'off'
 env:
   browser: false
   es6:     true

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Found a bug? Have a question? Want to request a feature? [Open an issue!][new-is
 
 ## Testing
 
-* Tests are written using [Mocha][Mocha], and can be run on the command line using `npm test`.
+* Tests are written using [Mocha][Mocha] and [Chai][Chai], and can be run on the command line using `npm test`.
 
 * Test string fields using the [Big List of Naughty Strings][BLNS] whenever reasonable.
 
@@ -15,6 +15,7 @@ Found a bug? Have a question? Want to request a feature? [Open an issue!][new-is
 * Code from an older version of this project may be viewed [here][old-code]. Much of the code in this version may still be useful.
 
 [BLNS]:      https://www.npmjs.com/package/big-list-of-naughty-strings
+[Chai]:      https://www.chaijs.com/
 [Mocha]:     https://mochajs.org/
 [old-code]:  https://github.com/digitallinguistics/javascript/tree/0326ceef826573c5a90d99359fdd9e4e39c77fb3/archive
 [new-issue]: https://github.com/dwhieb/utilities/issues/new

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Found a bug? Have a question? Want to request a feature? [Open an issue!][new-is
 
 ## Testing
 
-* Tests are written using [Jasmine][Jasmine], and can be run on the command line using `npm test`.
+* Tests are written using [Mocha][Mocha], and can be run on the command line using `npm test`.
 
 * Test string fields using the [Big List of Naughty Strings][BLNS] whenever reasonable.
 
@@ -15,6 +15,6 @@ Found a bug? Have a question? Want to request a feature? [Open an issue!][new-is
 * Code from an older version of this project may be viewed [here][old-code]. Much of the code in this version may still be useful.
 
 [BLNS]:      https://www.npmjs.com/package/big-list-of-naughty-strings
-[Jasmine]:   https://jasmine.github.io/index.html
+[Mocha]:     https://mochajs.org/
 [old-code]:  https://github.com/digitallinguistics/javascript/tree/0326ceef826573c5a90d99359fdd9e4e39c77fb3/archive
 [new-issue]: https://github.com/dwhieb/utilities/issues/new

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,6 +237,12 @@
         "is-string": "^1.0.4"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -330,6 +336,20 @@
         "lodash": "^4.17.14"
       }
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -348,6 +368,12 @@
           "dev": true
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "3.3.1",
@@ -451,6 +477,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -812,12 +847,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "expect.js": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
-      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -968,6 +997,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "gh-pages": {
@@ -1746,6 +1781,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -2183,6 +2224,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -191,6 +191,16 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -214,6 +224,18 @@
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
+    },
+    "array.prototype.map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
+      "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.4"
+      }
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -250,6 +272,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -266,10 +294,31 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "catharsis": {
@@ -297,6 +346,50 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.3.0"
+      }
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
       }
     },
@@ -353,10 +446,31 @@
         "ms": "^2.1.1"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "doctrine": {
@@ -438,6 +552,57 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
       "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
       "dev": true
+    },
+    "es-abstract": {
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true
+    },
+    "es-get-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.4",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "escape-string-regexp": {
       "version": "2.0.0",
@@ -647,6 +812,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -701,6 +872,15 @@
         "humanize-url": "^1.0.0"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -720,6 +900,15 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
       }
     },
     "flat-cache": {
@@ -756,10 +945,29 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "gh-pages": {
@@ -828,10 +1036,37 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "htmlparser2": {
@@ -912,6 +1147,39 @@
         "sanitize-html": "^1.13.0"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -933,10 +1201,58 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
     "isexe": {
@@ -945,21 +1261,21 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "jasmine": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
-      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
+    "iterate-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
+      "dev": true
+    },
+    "iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.4",
-        "jasmine-core": "~3.5.0"
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
       }
-    },
-    "jasmine-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
-      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1122,6 +1438,15 @@
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -1194,6 +1519,87 @@
         "minimist": "0.0.8"
       }
     },
+    "mocha": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.1.tgz",
+      "integrity": "sha512-p7FuGlYH8t7gaiodlFreseLxEmxTgvyG9RgPHODFPySNhwUehu8NIb0vdSt3WFckSneswZ0Un5typYcWElk7HQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.1",
+        "debug": "3.2.6",
+        "diff": "4.0.2",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "4.1.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.2",
+        "object.assign": "4.1.0",
+        "promise.allsettled": "1.0.2",
+        "serialize-javascript": "4.0.0",
+        "strip-json-comments": "3.0.1",
+        "supports-color": "7.1.0",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.0.0",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -1210,6 +1616,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
     "normalize-url": {
@@ -1229,6 +1641,30 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1310,6 +1746,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1380,6 +1822,19 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise.allsettled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+      "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
+      "dev": true,
+      "requires": {
+        "array.prototype.map": "^1.0.1",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "iterate-value": "^1.0.0"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1396,10 +1851,40 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.7"
+      }
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "requizzle": {
@@ -1435,6 +1920,12 @@
         "glob": "^7.1.3"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
     "sanitize-html": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.22.0.tgz",
@@ -1457,6 +1948,21 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
       "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shebang-command": {
@@ -1546,6 +2052,26 @@
         }
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -1623,6 +2149,15 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -1697,11 +2232,87 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "workerpool": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
+      "integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1729,6 +2340,154 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+      "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "decamelize": "^1.2.0",
+        "flat": "^4.1.0",
+        "is-plain-obj": "^1.1.0",
+        "yargs": "^14.2.3"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "language documentation",
     "documentary linguistics"
   ],
+  "type": "module",
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",
@@ -28,7 +29,7 @@
   },
   "scripts": {
     "docs": "jsdoc -c jsdoc.json",
-    "test": "jasmine --config=test/jasmine.json"
+    "test": "mocha src --recursive"
   },
   "repository": {
     "type": "git",
@@ -51,9 +52,10 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^7.4.0",
     "esm": "^3.2.25",
+    "expect.js": "^0.3.1",
     "gh-pages": "^3.1.0",
     "ink-docstrap": "^1.3.2",
-    "jasmine": "^3.5.0",
-    "jsdoc": "^3.6.4"
+    "jsdoc": "^3.6.4",
+    "mocha": "^8.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
+    "chai": "^4.2.0",
     "eslint": "^7.4.0",
     "esm": "^3.2.25",
-    "expect.js": "^0.3.1",
     "gh-pages": "^3.1.0",
     "ink-docstrap": "^1.3.2",
     "jsdoc": "^3.6.4",

--- a/src/core/Model.test.js
+++ b/src/core/Model.test.js
@@ -6,7 +6,7 @@ const { expect } = chai;
 describe(`Model`, () => {
 
   it(`is the Model class`, () => {
-    expect(Model.name).toBe(`Model`);
+    expect(Model.name).to.equal(`Model`);
   });
 
 });

--- a/src/core/Model.test.js
+++ b/src/core/Model.test.js
@@ -1,12 +1,12 @@
 import chai  from 'chai';
 import Model from './Model.js';
 
-const { expect } = chai;
+chai.should();
 
 describe(`Model`, () => {
 
   it(`is the Model class`, () => {
-    expect(Model.name).to.equal(`Model`);
+    Model.name.should.equal(`Model`);
   });
 
 });

--- a/src/core/Model.test.js
+++ b/src/core/Model.test.js
@@ -1,5 +1,7 @@
-import expect from 'expect.js';
-import Model  from './Model.js';
+import chai  from 'chai';
+import Model from './Model.js';
+
+const { expect } = chai;
 
 describe(`Model`, () => {
 

--- a/src/core/Model.test.js
+++ b/src/core/Model.test.js
@@ -1,4 +1,5 @@
-const { core: { Model } } = require(`../../test`);
+import expect from 'expect.js';
+import Model  from './Model.js';
 
 describe(`Model`, () => {
 

--- a/src/core/index.test.js
+++ b/src/core/index.test.js
@@ -1,8 +1,8 @@
 import chai from 'chai';
 import core from './index.js';
 
-const { expect } = chai;
-const { Model }  = core;
+const { Model } = core;
+chai.should();
 
 /**
  * Check that the core module has the expected exports
@@ -11,7 +11,7 @@ const { Model }  = core;
 describe(`core`, () => {
 
   it(`Model`, () => {
-    expect(Model.name).to.equal(`Model`);
+    Model.name.should.equal(`Model`);
   });
 
 });

--- a/src/core/index.test.js
+++ b/src/core/index.test.js
@@ -1,7 +1,8 @@
-import core   from './index.js';
-import expect from 'expect.js';
+import chai from 'chai';
+import core from './index.js';
 
-const { Model } = core;
+const { expect } = chai;
+const { Model }  = core;
 
 /**
  * Check that the core module has the expected exports

--- a/src/core/index.test.js
+++ b/src/core/index.test.js
@@ -1,4 +1,5 @@
-const { core } = require(`../../test/index.js`);
+import core   from './index.js';
+import expect from 'expect.js';
 
 const { Model } = core;
 

--- a/src/core/index.test.js
+++ b/src/core/index.test.js
@@ -11,7 +11,7 @@ const { Model }  = core;
 describe(`core`, () => {
 
   it(`Model`, () => {
-    expect(Model.name).toBe(`Model`);
+    expect(Model.name).to.equal(`Model`);
   });
 
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export { default as core } from './core/index.js';
-export { default as models } from './models/index.js';
-export { default as utilities } from './utilities/index.js';
+export * as core from './core/index.js';
+export * as models from './models/index.js';
+export * as utilities from './utilities/index.js';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,7 @@
 import chai                        from 'chai';
 import { core, models, utilities } from './index.js';
 
-const { expect } = chai;
+const should = chai.should();
 
 /**
  * Check that the DLx library has the expected exports
@@ -10,15 +10,15 @@ const { expect } = chai;
 describe(`dlx`, () => {
 
   it(`core`, () => {
-    expect(core).not.to.be.undefined;
+    should.exist(core);
   });
 
   it(`models`, () => {
-    expect(models).not.to.be.undefined;
+    should.exist(models);
   });
 
   it(`utilities`, () => {
-    expect(utilities).not.to.be.undefined;
+    should.exist(utilities);
   });
 
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,5 @@
-const { core, models, utilities } = require(`../test`);
+import expect                      from 'expect.js';
+import { core, models, utilities } from './index.js';
 
 /**
  * Check that the DLx library has the expected exports

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,15 +10,15 @@ const { expect } = chai;
 describe(`dlx`, () => {
 
   it(`core`, () => {
-    expect(core).toBeInstanceOf(Object);
+    expect(core).not.to.be.undefined;
   });
 
   it(`models`, () => {
-    expect(models).toBeInstanceOf(Object);
+    expect(models).not.to.be.undefined;
   });
 
   it(`utilities`, () => {
-    expect(utilities).toBeInstanceOf(Object);
+    expect(utilities).not.to.be.undefined;
   });
 
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,7 @@
-import expect                      from 'expect.js';
+import chai                        from 'chai';
 import { core, models, utilities } from './index.js';
+
+const { expect } = chai;
 
 /**
  * Check that the DLx library has the expected exports

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -2,12 +2,9 @@
   max-nested-callbacks,
 */
 
-const { models } = require(`../../test`);
+import expect from 'expect.js';
 
-const {
-  MultiLangString,
-  Language,
-} = models;
+import { Language, MultiLangString } from './index.js';
 
 describe(`Language`, () => {
 

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -10,46 +10,46 @@ const { expect } = chai;
 describe(`Language`, () => {
 
   it(`class: Language`, () => {
-    expect(Language.name).toBe(`Language`);
+    expect(Language.name).to.equal(`Language`);
   });
 
   it(`Abbreviation`, () => {
     const lang = new Language;
-    expect(() => { lang.abbreviation = undefined; }).not.toThrow();
-    expect(() => { lang.abbreviation = `ctm`; }).not.toThrow();
-    expect(() => { lang.abbreviation = `en!`; }).toThrowMatching(e => e.name === `AbbreviationError`);
+    expect(() => { lang.abbreviation = undefined; }).not.to.throw();
+    expect(() => { lang.abbreviation = `ctm`; }).not.to.throw();
+    expect(() => { lang.abbreviation = `en!`; }).to.throw().with.property(`name`, `AbbreviationError`);
   });
 
   it(`Custom Property`, () => {
     const lang = new Language;
-    expect(() => { lang.deleted = true; }).not.toThrow();
-    expect(lang.deleted).toBe(true);
+    expect(() => { lang.deleted = true; }).not.to.throw();
+    expect(lang.deleted).to.equal(true);
   });
 
   it(`Glottocode`, () => {
     const lang = new Language;
-    expect(() => { lang.glottolog = undefined; }).not.toThrow();
-    expect(() => { lang.glottolog = `stan1293`; }).not.toThrow();
-    expect(() => { lang.glottolog = `stan129`; }).toThrowMatching(e => e.name === `GlottoCodeError`);
+    expect(() => { lang.glottolog = undefined; }).not.to.throw();
+    expect(() => { lang.glottolog = `stan1293`; }).not.to.throw();
+    expect(() => { lang.glottolog = `stan129`; }).to.throw().with.property(`name`, `GlottoCodeError`);
   });
 
   it(`ISO 639-3 code`, () => {
     const lang = new Language;
-    expect(() => { lang.iso = undefined; }).not.toThrow();
-    expect(() => { lang.iso = `ctm`; }).not.toThrow();
-    expect(() => { lang.iso = `en`; }).toThrowMatching(e => e.name === `ISOCodeError`);
+    expect(() => { lang.iso = undefined; }).not.to.throw();
+    expect(() => { lang.iso = `ctm`; }).not.to.throw();
+    expect(() => { lang.iso = `en`; }).to.throw().with.property(`name`, `ISOCodeError`);
   });
 
   describe(`name`, () => {
 
     it(`class: MultiLangString`, () => {
       const lang = new Language();
-      expect(lang.name).toBeInstanceOf(MultiLangString);
+      expect(lang.name).to.be.instanceOf(MultiLangString);
     });
 
     it(`enumerable`, () => {
       const lang = new Language({ name: 'Chitimacha' });
-      expect(Object.keys(lang)).toContain(`name`);
+      expect(Object.keys(lang)).to.contain(`name`);
     });
 
     it(`Success: String`, () => {
@@ -59,7 +59,7 @@ describe(`Language`, () => {
 
       lang.name = name;
 
-      expect(lang.name.get(`eng`)).toBe(name);
+      expect(lang.name.get(`eng`)).to.equal(name);
 
     });
 
@@ -74,15 +74,15 @@ describe(`Language`, () => {
 
       lang.name = name;
 
-      expect(lang.name.get(`eng`)).toBe(name.eng);
-      expect(lang.name.get(`fra`)).toBe(name.fra);
+      expect(lang.name.get(`eng`)).to.equal(name.eng);
+      expect(lang.name.get(`fra`)).to.equal(name.fra);
 
     });
 
     it(`Error: bad data`, () => {
       const lang = new Language;
       const setBadLang = () => { lang.name = false; };
-      expect(setBadLang).toThrowMatching(e => e.name === `MultiLangStringDataError`);
+      expect(setBadLang).to.throw().with.property(`name`, `MultiLangStringDataError`);
     });
 
   });

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -2,9 +2,10 @@
   max-nested-callbacks,
 */
 
-import expect from 'expect.js';
-
+import chai from 'chai';
 import { Language, MultiLangString } from './index.js';
+
+const { expect } = chai;
 
 describe(`Language`, () => {
 

--- a/src/models/Language.test.js
+++ b/src/models/Language.test.js
@@ -5,51 +5,51 @@
 import chai from 'chai';
 import { Language, MultiLangString } from './index.js';
 
-const { expect } = chai;
+chai.should();
 
 describe(`Language`, () => {
 
   it(`class: Language`, () => {
-    expect(Language.name).to.equal(`Language`);
+    Language.name.should.equal(`Language`);
   });
 
   it(`Abbreviation`, () => {
     const lang = new Language;
-    expect(() => { lang.abbreviation = undefined; }).not.to.throw();
-    expect(() => { lang.abbreviation = `ctm`; }).not.to.throw();
-    expect(() => { lang.abbreviation = `en!`; }).to.throw().with.property(`name`, `AbbreviationError`);
+    (() => { lang.abbreviation = undefined; }).should.not.throw();
+    (() => { lang.abbreviation = `ctm`; }).should.not.throw();
+    (() => { lang.abbreviation = `en!`; }).should.throw().with.property(`name`, `AbbreviationError`);
   });
 
   it(`Custom Property`, () => {
     const lang = new Language;
-    expect(() => { lang.deleted = true; }).not.to.throw();
-    expect(lang.deleted).to.equal(true);
+    (() => { lang.deleted = true; }).should.not.throw();
+    lang.deleted.should.equal(true);
   });
 
   it(`Glottocode`, () => {
     const lang = new Language;
-    expect(() => { lang.glottolog = undefined; }).not.to.throw();
-    expect(() => { lang.glottolog = `stan1293`; }).not.to.throw();
-    expect(() => { lang.glottolog = `stan129`; }).to.throw().with.property(`name`, `GlottoCodeError`);
+    (() => { lang.glottolog = undefined; }).should.not.throw();
+    (() => { lang.glottolog = `stan1293`; }).should.not.throw();
+    (() => { lang.glottolog = `stan129`; }).should.throw().with.property(`name`, `GlottoCodeError`);
   });
 
   it(`ISO 639-3 code`, () => {
     const lang = new Language;
-    expect(() => { lang.iso = undefined; }).not.to.throw();
-    expect(() => { lang.iso = `ctm`; }).not.to.throw();
-    expect(() => { lang.iso = `en`; }).to.throw().with.property(`name`, `ISOCodeError`);
+    (() => { lang.iso = undefined; }).should.not.throw();
+    (() => { lang.iso = `ctm`; }).should.not.throw();
+    (() => { lang.iso = `en`; }).should.throw().with.property(`name`, `ISOCodeError`);
   });
 
   describe(`name`, () => {
 
     it(`class: MultiLangString`, () => {
       const lang = new Language();
-      expect(lang.name).to.be.instanceOf(MultiLangString);
+      lang.name.should.be.instanceOf(MultiLangString);
     });
 
     it(`enumerable`, () => {
       const lang = new Language({ name: 'Chitimacha' });
-      expect(Object.keys(lang)).to.contain(`name`);
+      Object.keys(lang).should.contain(`name`);
     });
 
     it(`Success: String`, () => {
@@ -59,7 +59,7 @@ describe(`Language`, () => {
 
       lang.name = name;
 
-      expect(lang.name.get(`eng`)).to.equal(name);
+      lang.name.get(`eng`).should.equal(name);
 
     });
 
@@ -74,15 +74,15 @@ describe(`Language`, () => {
 
       lang.name = name;
 
-      expect(lang.name.get(`eng`)).to.equal(name.eng);
-      expect(lang.name.get(`fra`)).to.equal(name.fra);
+      lang.name.get(`eng`).should.equal(name.eng);
+      lang.name.get(`fra`).should.equal(name.fra);
 
     });
 
     it(`Error: bad data`, () => {
       const lang = new Language;
       const setBadLang = () => { lang.name = false; };
-      expect(setBadLang).to.throw().with.property(`name`, `MultiLangStringDataError`);
+      setBadLang.should.throw().with.property(`name`, `MultiLangStringDataError`);
     });
 
   });

--- a/src/models/MultiLangString.test.js
+++ b/src/models/MultiLangString.test.js
@@ -2,9 +2,11 @@
   max-nested-callbacks,
 */
 
-import expect          from 'expect.js';
+import chai            from 'chai';
 import Model           from '../core/Model.js';
 import MultiLangString from './MultiLangString.js';
+
+const { expect } = chai;
 
 const modelName = `MultiLangString`;
 

--- a/src/models/MultiLangString.test.js
+++ b/src/models/MultiLangString.test.js
@@ -15,8 +15,8 @@ const sampleData = { eng: 'Hello world!', spa: 'Hola mundo!' };
 describe(modelName, () => {
 
   it(`class: MultiLangString`, () => {
-    expect(MultiLangString.name).toBe(modelName);
-    expect(new MultiLangString).not.toBeInstanceOf(Model);
+    expect(MultiLangString.name).to.equal(modelName);
+    expect(new MultiLangString).not.to.be.instanceOf(Model);
   });
 
   describe(`data`, () => {
@@ -24,49 +24,49 @@ describe(modelName, () => {
     it(`String`, () => {
       const data = `hello`;
       const mls  = new MultiLangString(data);
-      expect(mls.get(`eng`)).toBe(data);
+      expect(mls.get(`eng`)).to.equal(data);
     });
 
     it(`empty String`, () => {
       const mls = new MultiLangString(``);
-      expect(mls.size).toBe(0);
+      expect(mls.size).to.equal(0);
     });
 
     it(`Object`, () => {
       const data = { eng: `hello` };
       const mls  = new MultiLangString(data);
-      expect(mls.get(`eng`)).toBe(data.eng);
+      expect(mls.get(`eng`)).to.equal(data.eng);
     });
 
     it(`empty Object`, () => {
       const mls  = new MultiLangString({});
-      expect(mls.size).toBe(0);
+      expect(mls.size).to.equal(0);
     });
 
     it(`Map`, () => {
       const data = new Map([[`eng`, `hello`]]);
       const mls  = new MultiLangString(data);
-      expect(mls.get(`eng`)).toBe(data.get(`eng`));
+      expect(mls.get(`eng`)).to.equal(data.get(`eng`));
     });
 
     it(`empty Map`, () => {
       const mls = new MultiLangString(new Map);
-      expect(mls.size).toBe(0);
+      expect(mls.size).to.equal(0);
     });
 
     it(`Error: bad data`, () => {
       const useBadData = () => new MultiLangString(0);
-      expect(useBadData).toThrowMatching(e => e.name === `MultiLangStringDataError`);
+      expect(useBadData).to.throw().with.property(`name`, `MultiLangStringDataError`);
     });
 
     it(`Error: bad language tag`, () => {
       const useBadLanguageTag = () => new MultiLangString({ 'eng.1': 'Hello world!' });
-      expect(useBadLanguageTag).toThrowMatching(e => e.name === `LanguageTagError`);
+      expect(useBadLanguageTag).to.throw().with.property(`name`, `LanguageTagError`);
     });
 
     it(`Error: bad string`, () => {
       const useBadString = () => new MultiLangString({ eng: 42 });
-      expect(useBadString).toThrowMatching(e => e.name === `MultiLangStringError`);
+      expect(useBadString).to.throw().with.property(`name`, `MultiLangStringError`);
     });
 
   });
@@ -75,20 +75,20 @@ describe(modelName, () => {
 
     it(`Instantiation`, () => {
       const mls = new MultiLangString(sampleData);
-      expect(mls.get(`eng`)).toBe(sampleData.eng);
-      expect(mls.get(`spa`)).toBe(sampleData.spa);
+      expect(mls.get(`eng`)).to.equal(sampleData.eng);
+      expect(mls.get(`spa`)).to.equal(sampleData.spa);
     });
 
     it(`Error: set bad language tag`, () => {
       const mls = new MultiLangString(sampleData);
       const setBadLanguageTag = () => mls.set(`Tlahuapa Mixtec`, `ayoo`);
-      expect(setBadLanguageTag).toThrowMatching(e => e.name === `LanguageTagError`);
+      expect(setBadLanguageTag).to.throw().with.property(`name`, `LanguageTagError`);
     });
 
     it(`Error: set bad string`, () => {
       const mls = new MultiLangString(sampleData);
       const setBadString = () => mls.set(`mix`, true);
-      expect(setBadString).toThrowMatching(e => e.name === `MultiLangStringError`);
+      expect(setBadString).to.throw().with.property(`name`, `MultiLangStringError`);
     });
 
   });
@@ -96,7 +96,7 @@ describe(modelName, () => {
   it(`.set()`, () => {
     const mls = new MultiLangString;
     const setData = () => mls.set(`hello`, `world`);
-    expect(setData).not.toThrow();
+    expect(setData).not.to.throw();
   });
 
   it(`.toJSON()`, () => {
@@ -105,12 +105,12 @@ describe(modelName, () => {
     const pojo = JSON.parse(JSON.stringify(mls));
 
     Object.keys(sampleData)
-    .forEach(key => expect(pojo[key]).toBe(sampleData[key]));
+    .forEach(key => expect(pojo[key]).to.equal(sampleData[key]));
 
   });
 
-  it(`~~.type~~`, () => {
-    expect(new MultiLangString().type).toBeUndefined();
+  it(`.type (should not exist)`, () => {
+    expect(new MultiLangString().type).to.be.undefined;
   });
 
 });

--- a/src/models/MultiLangString.test.js
+++ b/src/models/MultiLangString.test.js
@@ -2,10 +2,9 @@
   max-nested-callbacks,
 */
 
-const {
-  core:   { Model },
-  models: { MultiLangString },
-} = require(`../../test`);
+import expect          from 'expect.js';
+import Model           from '../core/Model.js';
+import MultiLangString from './MultiLangString.js';
 
 const modelName = `MultiLangString`;
 

--- a/src/models/MultiLangString.test.js
+++ b/src/models/MultiLangString.test.js
@@ -6,7 +6,7 @@ import chai            from 'chai';
 import Model           from '../core/Model.js';
 import MultiLangString from './MultiLangString.js';
 
-const { expect } = chai;
+const should = chai.should();
 
 const modelName = `MultiLangString`;
 
@@ -15,8 +15,8 @@ const sampleData = { eng: 'Hello world!', spa: 'Hola mundo!' };
 describe(modelName, () => {
 
   it(`class: MultiLangString`, () => {
-    expect(MultiLangString.name).to.equal(modelName);
-    expect(new MultiLangString).not.to.be.instanceOf(Model);
+    MultiLangString.name.should.equal(modelName);
+    (new MultiLangString).should.not.to.be.instanceOf(Model);
   });
 
   describe(`data`, () => {
@@ -24,49 +24,49 @@ describe(modelName, () => {
     it(`String`, () => {
       const data = `hello`;
       const mls  = new MultiLangString(data);
-      expect(mls.get(`eng`)).to.equal(data);
+      mls.get(`eng`).should.equal(data);
     });
 
     it(`empty String`, () => {
       const mls = new MultiLangString(``);
-      expect(mls.size).to.equal(0);
+      mls.size.should.equal(0);
     });
 
     it(`Object`, () => {
       const data = { eng: `hello` };
       const mls  = new MultiLangString(data);
-      expect(mls.get(`eng`)).to.equal(data.eng);
+      mls.get(`eng`).should.equal(data.eng);
     });
 
     it(`empty Object`, () => {
       const mls  = new MultiLangString({});
-      expect(mls.size).to.equal(0);
+      mls.size.should.equal(0);
     });
 
     it(`Map`, () => {
       const data = new Map([[`eng`, `hello`]]);
       const mls  = new MultiLangString(data);
-      expect(mls.get(`eng`)).to.equal(data.get(`eng`));
+      mls.get(`eng`).should.equal(data.get(`eng`));
     });
 
     it(`empty Map`, () => {
       const mls = new MultiLangString(new Map);
-      expect(mls.size).to.equal(0);
+      mls.size.should.equal(0);
     });
 
     it(`Error: bad data`, () => {
       const useBadData = () => new MultiLangString(0);
-      expect(useBadData).to.throw().with.property(`name`, `MultiLangStringDataError`);
+      useBadData.should.throw().with.property(`name`, `MultiLangStringDataError`);
     });
 
     it(`Error: bad language tag`, () => {
       const useBadLanguageTag = () => new MultiLangString({ 'eng.1': 'Hello world!' });
-      expect(useBadLanguageTag).to.throw().with.property(`name`, `LanguageTagError`);
+      useBadLanguageTag.should.throw().with.property(`name`, `LanguageTagError`);
     });
 
     it(`Error: bad string`, () => {
       const useBadString = () => new MultiLangString({ eng: 42 });
-      expect(useBadString).to.throw().with.property(`name`, `MultiLangStringError`);
+      useBadString.should.throw().with.property(`name`, `MultiLangStringError`);
     });
 
   });
@@ -75,20 +75,20 @@ describe(modelName, () => {
 
     it(`Instantiation`, () => {
       const mls = new MultiLangString(sampleData);
-      expect(mls.get(`eng`)).to.equal(sampleData.eng);
-      expect(mls.get(`spa`)).to.equal(sampleData.spa);
+      mls.get(`eng`).should.equal(sampleData.eng);
+      mls.get(`spa`).should.equal(sampleData.spa);
     });
 
     it(`Error: set bad language tag`, () => {
       const mls = new MultiLangString(sampleData);
       const setBadLanguageTag = () => mls.set(`Tlahuapa Mixtec`, `ayoo`);
-      expect(setBadLanguageTag).to.throw().with.property(`name`, `LanguageTagError`);
+      setBadLanguageTag.should.throw().with.property(`name`, `LanguageTagError`);
     });
 
     it(`Error: set bad string`, () => {
       const mls = new MultiLangString(sampleData);
       const setBadString = () => mls.set(`mix`, true);
-      expect(setBadString).to.throw().with.property(`name`, `MultiLangStringError`);
+      setBadString.should.throw().with.property(`name`, `MultiLangStringError`);
     });
 
   });
@@ -96,7 +96,7 @@ describe(modelName, () => {
   it(`.set()`, () => {
     const mls = new MultiLangString;
     const setData = () => mls.set(`hello`, `world`);
-    expect(setData).not.to.throw();
+    setData.should.not.throw();
   });
 
   it(`.toJSON()`, () => {
@@ -105,12 +105,12 @@ describe(modelName, () => {
     const pojo = JSON.parse(JSON.stringify(mls));
 
     Object.keys(sampleData)
-    .forEach(key => expect(pojo[key]).to.equal(sampleData[key]));
+    .forEach(key => pojo[key].should.equal(sampleData[key]));
 
   });
 
   it(`.type (should not exist)`, () => {
-    expect(new MultiLangString().type).to.be.undefined;
+    should.not.exist(new MultiLangString().type);
   });
 
 });

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -3,10 +3,5 @@
  * @namespace models
  */
 
-import Language        from './Language.js';
-import MultiLangString from './MultiLangString.js';
-
-export default {
-  Language,
-  MultiLangString,
-};
+export { default as Language } from './Language.js';
+export { default as MultiLangString } from './MultiLangString.js';

--- a/src/models/index.test.js
+++ b/src/models/index.test.js
@@ -5,13 +5,13 @@
 import chai                          from 'chai';
 import { Language, MultiLangString } from './index.js';
 
-const { expect } = chai;
+chai.should();
 
 describe(`models`, () => {
 
   it(`has the expected exports`, () => {
-    expect(MultiLangString.name).to.equal(`MultiLangString`);
-    expect(Language.name).to.equal(`Language`);
+    MultiLangString.name.should.equal(`MultiLangString`);
+    Language.name.should.equal(`Language`);
   });
 
 });

--- a/src/models/index.test.js
+++ b/src/models/index.test.js
@@ -2,8 +2,10 @@
   max-nested-callbacks,
 */
 
-import expect                        from 'expect.js';
+import chai                          from 'chai';
 import { Language, MultiLangString } from './index.js';
+
+const { expect } = chai;
 
 describe(`models`, () => {
 

--- a/src/models/index.test.js
+++ b/src/models/index.test.js
@@ -2,12 +2,8 @@
   max-nested-callbacks,
 */
 
-const { models } = require(`../../test`);
-
-const {
-  MultiLangString,
-  Language,
-} = models;
+import expect                        from 'expect.js';
+import { Language, MultiLangString } from './index.js';
 
 describe(`models`, () => {
 

--- a/src/models/index.test.js
+++ b/src/models/index.test.js
@@ -10,8 +10,8 @@ const { expect } = chai;
 describe(`models`, () => {
 
   it(`has the expected exports`, () => {
-    expect(MultiLangString.name).toBe(`MultiLangString`);
-    expect(Language.name).toBe(`Language`);
+    expect(MultiLangString.name).to.equal(`MultiLangString`);
+    expect(Language.name).to.equal(`Language`);
   });
 
 });

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -3,10 +3,5 @@
  * @namespace utilities
  */
 
-import regexp from './regexp/index.js';
-import types  from './types/index.js';
-
-export default {
-  regexp,
-  types,
-};
+export * as regexp from './regexp/index.js';
+export * as types from './types/index.js';

--- a/src/utilities/index.test.js
+++ b/src/utilities/index.test.js
@@ -10,11 +10,11 @@ const { expect } = chai;
 describe(`utilities`, () => {
 
   it(`regexp`, () => {
-    expect(regexp).toBeInstanceOf(Object);
+    expect(regexp).not.to.be.undefined;
   });
 
   it(`types`, () => {
-    expect(types).toBeInstanceOf(Object);
+    expect(types).not.to.be.undefined;
   });
 
 });

--- a/src/utilities/index.test.js
+++ b/src/utilities/index.test.js
@@ -1,5 +1,7 @@
-import expect            from 'expect.js';
+import chai              from 'chai';
 import { regexp, types } from './index.js';
+
+const { expect } = chai;
 
 /**
  * Check that the utilities module has the expected exports

--- a/src/utilities/index.test.js
+++ b/src/utilities/index.test.js
@@ -1,6 +1,5 @@
-const { utilities } = require(`../../test`);
-
-const { regexp, types } = utilities;
+import expect            from 'expect.js';
+import { regexp, types } from './index.js';
 
 /**
  * Check that the utilities module has the expected exports

--- a/src/utilities/index.test.js
+++ b/src/utilities/index.test.js
@@ -1,7 +1,7 @@
 import chai              from 'chai';
 import { regexp, types } from './index.js';
 
-const { expect } = chai;
+const should = chai.should();
 
 /**
  * Check that the utilities module has the expected exports
@@ -10,11 +10,11 @@ const { expect } = chai;
 describe(`utilities`, () => {
 
   it(`regexp`, () => {
-    expect(regexp).not.to.be.undefined;
+    should.exist(regexp);
   });
 
   it(`types`, () => {
-    expect(types).not.to.be.undefined;
+    should.exist(types);
   });
 
 });

--- a/src/utilities/regexp/index.js
+++ b/src/utilities/regexp/index.js
@@ -3,15 +3,7 @@
  * @namespace utilities.regexp
  */
 
-import abbreviationRegExp from './Abbreviation.js';
-import glottoCodeRegExp   from './Glottolog.js';
-import isoCodeRegExp      from './ISO.js';
-import languageTagRegExp  from './languageTag.js';
-
-
-export default {
-  abbreviationRegExp,
-  glottoCodeRegExp,
-  isoCodeRegExp,
-  languageTagRegExp,
-};
+export { default as abbreviationRegExp } from './Abbreviation.js';
+export { default as glottoCodeRegExp } from './Glottolog.js';
+export { default as isoCodeRegExp } from './ISO.js';
+export { default as languageTagRegExp } from './languageTag.js';

--- a/src/utilities/types/index.js
+++ b/src/utilities/types/index.js
@@ -3,14 +3,7 @@
  * @namespace utilities.types
  */
 
-import isAbbreviation from './isAbbreviation.js';
-import isGlottoCode   from './isGlottoCode.js';
-import isISOCode      from './isISO.js';
-import isLanguageTag  from './isLanguageTag.js';
-
-export default {
-  isAbbreviation,
-  isGlottoCode,
-  isISOCode,
-  isLanguageTag,
-};
+export { default as isAbbreviation } from './isAbbreviation.js';
+export { default as isGlottoCode } from './isGlottoCode.js';
+export { default as isISOCode } from './isISO.js';
+export { default as isLanguageTag } from './isLanguageTag.js';

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,0 @@
-require = require(`esm`)(module);
-
-module.exports = require(`../src/index.js`);

--- a/test/jasmine.json
+++ b/test/jasmine.json
@@ -1,6 +1,0 @@
-{
-  "spec_dir": "src",
-  "spec_files": ["**/*.test.js"],
-  "random": true,
-  "stopSpecOnExpectationFailure": true
-}


### PR DESCRIPTION
## Related Issue

closes #137

## Description

Jasmine does not natively support ES modules, and generally isn't well-maintained these days. This simplifies the testing somewhat. Note that the assertion style has changed:

https://www.chaijs.com/guide/styles/#should